### PR TITLE
Fix compatibility with Cinnamon 2.2.14 (and maybe some other versions).

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -6,7 +6,6 @@ const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
 const Util = imports.misc.util;
 const PopupMenu = imports.ui.popupMenu;
-const Calendar = imports.ui.calendar;
 const UPowerGlib = imports.gi.UPowerGlib;
 const PanelMenu = imports.ui.panelMenu;
 const Main = imports.ui.main;


### PR DESCRIPTION
I could not load the applet with Cinnamon 2.2.14.
This patch seems to make it work.
