### PR TITLE
Inhibit flags should be 8 and not 9

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -138,7 +138,7 @@ MyApplet.prototype = {
                 this._sessionProxy.InhibitRemote("inhibitor-screen-inhibit@mtwebster",
                                                  0, 
                                                  "inhibit mode",
-                                                 9,
+                                                 8,
                                                  Lang.bind(this, this._onInhibit));
                 this.set_applet_tooltip(INHIBIT_TT); 
                 this.inhibited = true;


### PR DESCRIPTION
See: 
[Gnome documentation](https://people.gnome.org/~mccann/gnome-session/docs/gnome-session.html#org.gnome.SessionManager.Inhibit)
1: Inhibit logging out
2: Inhibit user switching
4: Inhibit suspending the session or computer
8: Inhibit the session being marked as idle

Flags = 9 implies inhibit session being marked as idle (screensaver inhibit) PLUS inhibit logging out
If flags is 9, side effect is that if user tries to logout, user will see a warning that inhibit-screensaver is running
